### PR TITLE
Switching default host to be Microsoft Office (live/hotmail/outlook) …

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,8 @@ from yahooquery import Ticker
 import aiosmtplib
 
 # Email script from https://github.com/acamso/demos/blob/master/_email/send_txt_msg.py
-HOST = "smtp.gmail.com"
+#HOST = "smtp.gmail.com"
+HOST = "smtp.office365.com"
 
 CARRIER_MAP = {
     "verizon": "vtext.com",


### PR DESCRIPTION
…emails

GMAIL webservers getting rate limited to hell. The email -> SMS email that verizon provides is adding a 2 hr delay to gmail sent emails. The office365 email comes through SMS within about 25-30 seconds.